### PR TITLE
Dockerfile distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.corp.furiosa.ai/furiosa/libfuriosa-kubernetes:latest as build
+ARG BASE_IMAGE=registry.corp.furiosa.ai/furiosa/libfuriosa-kubernetes:latest
+FROM $BASE_IMAGE as build
 
 RUN apt-get update && apt-get install -y libssl-dev clang
 
@@ -8,7 +9,15 @@ COPY . /tmp
 
 RUN make build
 
-FROM registry.corp.furiosa.ai/furiosa/libfuriosa-kubernetes:latest
+FROM gcr.io/distroless/base-debian12:latest
 
+# Copy binary file
 COPY --from=build /tmp/target/release/furiosa-feature-discovery /opt/bin/furiosa-feature-discovery
+
+# Copy library files
+COPY --from=build /usr/lib/x86_64-linux-gnu/libfuriosa_smi.so /usr/lib/x86_64-linux-gnu/libfuriosa_smi.so
+COPY --from=build /usr/lib/x86_64-linux-gnu/libc.so.6 /usr/lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /usr/lib/x86_64-linux-gnu/libgcc_s.so.1 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /usr/lib/x86_64-linux-gnu/libm.so.6 /usr/lib/x86_64-linux-gnu/libm.so.6
+
 WORKDIR /opt/bin

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,52 @@
+BASE_IMAGE := registry.corp.furiosa.ai/furiosa/libfuriosa-kubernetes:latest
+
 ifeq ($(shell uname), Linux)
 export LD_LIBRARY_PATH := $(LD_LIBRARY_PATH):/usr/local/lib
 endif
 
-all: bake
+.PHONY: fmt
+fmt:
+	cargo fmt --all
+	# cargo machete # machete is not compatible with toolchain of this repo.
+	cargo sort --grouped --workspace
 
+.PHONY: clippy
+clippy:
+	cargo fmt --all --check && cargo -q clippy --all-targets -- -D rust_2018_idioms -D warnings
+
+.PHONY: submodule_init
 submodule_init:
 	git submodule init
 	git submodule update --init --recursive
 
+.PHONY: submodule_update
 submodule_update:
 	git submodule update --remote --merge
 
+.PHONY: clean
 clean:
 	cargo clean
 
+.PHONY: build
 build: submodule_init
 	cargo build --release
 
 .PHONY: image
 image:
-	docker build . -t registry.corp.furiosa.ai/furiosa/furiosa-feature-discovery:devel --progress=plain --platform=linux/amd64
+	docker build . -t registry.corp.furiosa.ai/furiosa/furiosa-feature-discovery:devel --progress=plain --platform=linux/amd64 --build-arg BASE_IMAGE=$(BASE_IMAGE)
 
 .PHONY: image-no-cache
 image-no-cache:
-	docker build . --no-cache -t registry.corp.furiosa.ai/furiosa/furiosa-feature-discovery:devel --progress=plain --platform=linux/amd64
+	docker build . --no-cache -t registry.corp.furiosa.ai/furiosa/furiosa-feature-discovery:devel --progress=plain --platform=linux/amd64 --build-arg BASE_IMAGE=$(BASE_IMAGE)
 
+.PHONY: image-rel
+image-rel:
+	docker build . -t registry.corp.furiosa.ai/furiosa/furiosa-feature-discovery:latest --progress=plain --platform=linux/amd64 --build-arg BASE_IMAGE=$(BASE_IMAGE)
+
+.PHONY: image-no-cache-rel
+image-no-cache-rel:
+	docker build . --no-cache -t registry.corp.furiosa.ai/furiosa/furiosa-feature-discovery:latest --progress=plain --platform=linux/amd64 --build-arg BASE_IMAGE=$(BASE_IMAGE)
+
+.PHONY: test
 test:
 	cargo test


### PR DESCRIPTION
This is PR for update Dockerfile.
- To support argument for base image
- Use distroless image for base image
  - Due to permission issue for generating nfd file, it uses root image rather than nonroot.