### PR TITLE
Add retry logic when fail to write labels

### DIFF
--- a/src/furiosa-feature-discovery.rs
+++ b/src/furiosa-feature-discovery.rs
@@ -124,24 +124,24 @@ fn remove_ffd(output_path: PathBuf) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn back_off_retry<F, Fut, Arg, Arg2>(
+async fn back_off_retry<F, Fut, ArgPath, ArgInterval>(
     retry_max: u64,
     func: F,
-    arg: Arg,
-    arg2: Arg2,
+    arg_path: ArgPath,
+    arg_interval: ArgInterval,
 ) -> anyhow::Result<()>
 where
-    F: Fn(Arg, Arg2) -> Fut + Send + 'static,
+    F: Fn(ArgPath, ArgInterval) -> Fut + Send + 'static,
     Fut: std::future::Future<Output = anyhow::Result<()>> + Send + 'static,
-    Arg: Clone + 'static,
-    Arg2: Clone + 'static,
+    ArgPath: Clone + 'static,
+    ArgInterval: Clone + 'static,
 {
     let mut attempts = 0;
     let mut retry_time = 0;
     let mut retry_interval;
 
     loop {
-        match func(arg.clone(), arg2.clone()).await {
+        match func(arg_path.clone(), arg_interval.clone()).await {
             Ok(()) => {
                 attempts = 0;
                 retry_time = 0;


### PR DESCRIPTION
### One line PR Description
[//]: # (If this PR references other issue, please paste that link into below `{ISSUE_LINK_HERE}` section and uncomment it.)
[//]: # (- resolve: {ISSUE_LINK_HERE})

https://furiosa-ai.slack.com/archives/C06DMGWTULF/p1732609188955979
For now, the program terminates when fail to write labels, then pod will be restarted.

This is PR to introduce retry logic before pod restarts.

Retry time is increased by 5 secs linearly.

### What type of PR is this?
[//]: # (Please add same label in your PR too.)

/kind feature


### Special notes for reviewer

https://github.com/furiosa-ai/furiosa-smi-rs/pull/26 should be merged before this