### PR TITLE
change return error when no NPU device exists

### DIFF
--- a/src/furiosa-feature-discovery.rs
+++ b/src/furiosa-feature-discovery.rs
@@ -212,8 +212,8 @@ async fn detect_npu_devices(
     let mut found = vec![];
 
     if devices.is_empty() {
-        log::info!("NPU device not found");
-        return Ok(found);
+        log::error!("If this is not a NPU node, please deploy this plugin on NPU nodes only by tolerations or nodeSelector.");
+        return Err(anyhow::Error::msg("couldn't recognize any furiosa devices"));
     }
 
     let driver = furiosa_smi_rs::driver_info()?;


### PR DESCRIPTION
### One line PR Description
[//]: # (If this PR references other issue, please paste that link into below `{ISSUE_LINK_HERE}` section and uncomment it.)
[//]: # (- resolve: {ISSUE_LINK_HERE})

This is PR to change to return error when no NPU device exists.

### What type of PR is this?
[//]: # (Please add same label in your PR too.)

/kind feature


### Special notes for reviewer
