### PR TITLE
fix typo for prerelease

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ The followings are the labels that the Furiosa Feature Discovery attaches and wh
    * - furiosa.ai/npu.driver.version.metadata
      - abcxyz
      - NPU device driver version metadata
-   * - furiosa.ai/npu.driver.version.prelease
+   * - furiosa.ai/npu.driver.version.prerelease
      - abcxyz
      - NPU device driver version pre-release part
    * - furiosa.ai/npu.firmware.version
@@ -90,7 +90,7 @@ The followings are the labels that the Furiosa Feature Discovery attaches and wh
    * - furiosa.ai/npu.firmware.version.metadata
      - abcxyz
      - NPU firmware version metadata
-   * - furiosa.ai/npu.firmware.version.prelease
+   * - furiosa.ai/npu.firmware.version.prerelease
      - abcxyz
      - NPU firmware version pre-release part
 

--- a/src/furiosa-feature-discovery.rs
+++ b/src/furiosa-feature-discovery.rs
@@ -310,7 +310,7 @@ mod tests {
             "1a2b3c".to_string(),
         );
         expected.insert(
-            "furiosa.ai/firmware.version.prelease".to_string(),
+            "furiosa.ai/firmware.version.prerelease".to_string(),
             "dev0".to_string(),
         );
         expected.insert("furiosa.ai/driver.version".to_string(), "1.2.3".to_string());
@@ -322,7 +322,7 @@ mod tests {
             "1a2b3c".to_string(),
         );
         expected.insert(
-            "furiosa.ai/driver.version.prelease".to_string(),
+            "furiosa.ai/driver.version.prerelease".to_string(),
             "dev0".to_string(),
         );
         expected.insert("furiosa.ai/npu.family".to_string(), "rngd".to_string());

--- a/src/npu.rs
+++ b/src/npu.rs
@@ -130,7 +130,7 @@ impl NpuDevice {
                 self.driver_info.clone().metadata().clone(),
             ),
             (
-                "furiosa.ai/driver.version.prelease".to_string(),
+                "furiosa.ai/driver.version.prerelease".to_string(),
                 self.driver_info.clone().prerelease().clone(),
             ),
         ];
@@ -157,7 +157,7 @@ impl NpuDevice {
                 firmware_info.clone().metadata().clone(),
             ));
             labels.push((
-                "furiosa.ai/firmware.version.prelease".to_string(),
+                "furiosa.ai/firmware.version.prerelease".to_string(),
                 firmware_info.clone().prerelease().clone(),
             ));
         };


### PR DESCRIPTION
### One line PR Description

Sync changes from final `2026.1.0` release preparation.

fix typos:
- `prelease` -> `prerelease`

### What type of PR is this?

/kind bug

### Special notes for reviewer
